### PR TITLE
Remove debug outlines and white boxes for cleaner visuals

### DIFF
--- a/js/gameEngine.js
+++ b/js/gameEngine.js
@@ -573,29 +573,18 @@
     // Draw background (which includes maze)
     drawBackground();
     
-    // Log render confirmation
-    console.log("Rendering - Maze dimensions:", 
-      gameState.maze ? `${gameState.maze.grid[0].length}x${gameState.maze.grid.length}` : "Maze not initialized");
-    
     // Draw player if available
     if (gameState.player) {
       gameState.player.draw(gameState.context);
-      
-      // Log player position
-      console.log("Player position:", 
-        `(${Math.round(gameState.player.x)}, ${Math.round(gameState.player.y)})`);
     } else {
       console.warn("No player to render");
     }
     
     // Draw ghosts if available
     if (gameState.ghosts && gameState.ghosts.length > 0) {
-      gameState.ghosts.forEach((ghost, index) => {
+      gameState.ghosts.forEach((ghost) => {
         ghost.draw(gameState.context);
       });
-      
-      // Log ghost count
-      console.log(`Rendered ${gameState.ghosts.length} ghosts`);
     } else {
       console.warn("No ghosts to render");
     }
@@ -660,10 +649,6 @@
     
     const { grid, cellSize, offsetX, offsetY } = gameState.maze;
     
-    // Log maze details
-    console.log("Drawing maze with:", 
-      `cellSize=${Math.round(cellSize)}, offset=(${Math.round(offsetX)},${Math.round(offsetY)})`);
-    
     // Draw the maze grid
     for (let row = 0; row < grid.length; row++) {
       for (let col = 0; col < grid[row].length; col++) {
@@ -673,11 +658,6 @@
         if (grid[row][col] === 1) { // Wall cell
           ctx.fillStyle = '#0000FF'; // Blue
           ctx.fillRect(x, y, cellSize, cellSize);
-          
-          // Add outline to walls for better visibility
-          ctx.strokeStyle = '#0000AA';
-          ctx.lineWidth = 1;
-          ctx.strokeRect(x, y, cellSize, cellSize);
         } else {
           // Draw path cells with emerald green
           ctx.fillStyle = '#08784e'; // Emerald green

--- a/js/ghost.js
+++ b/js/ghost.js
@@ -193,11 +193,6 @@
         return;
       }
       
-      // Add debug outline to see where ghost is positioned
-      context.strokeStyle = 'white';
-      context.lineWidth = 2;
-      context.strokeRect(this.x, this.y, this.width, this.height);
-      
       try {
         // Check if the image is available and loaded
         const imageLoadedCorrectly = this.image && this.image.width > 0 && this.image.height > 0;
@@ -212,9 +207,9 @@
             this.height
           );
           
-          // Add small white dot to confirm real image is drawn
-          context.fillStyle = 'white';
-          context.fillRect(this.x, this.y, 4, 4);
+          // Small indicator dot for debugging (can be commented out for production)
+          // context.fillStyle = 'white';
+          // context.fillRect(this.x, this.y, 4, 4);
           
           console.log("Drawing ghost with image:", 
             `dimensions=${this.width}x${this.height}, position=(${Math.round(this.x)},${Math.round(this.y)})`);
@@ -234,11 +229,6 @@
      * @param {CanvasRenderingContext2D} context - The canvas rendering context.
      */
     drawFallback(context) {
-      // Draw the ghost outline for visibility
-      context.strokeStyle = '#FFFFFF'; // White outline for better visibility
-      context.lineWidth = 2;
-      context.strokeRect(this.x, this.y, this.width, this.height);
-      
       // Determine ghost color based on the image reference - use very bright colors for visibility
       let ghostColor = '#FF0000'; // Bright red for default
       if (this.image && this.image.src) {
@@ -260,9 +250,6 @@
       context.arc(centerX, centerY, radius-2, 0, Math.PI * 2);
       context.fillStyle = ghostColor;
       context.fill();
-      context.strokeStyle = '#FFFFFF';
-      context.lineWidth = 1;
-      context.stroke();
       
       // Draw eyes - make larger for better visibility
       context.fillStyle = 'white';

--- a/js/player.js
+++ b/js/player.js
@@ -119,11 +119,6 @@
         return;
       }
 
-      // Add debug outline to see where player is positioned
-      context.strokeStyle = 'white';
-      context.lineWidth = 2;
-      context.strokeRect(this.x, this.y, this.width, this.height);
-      
       // Draw the appropriate image based on mouth state
       const image = this.mouthOpen ? this.faceOpen : this.faceClosed;
       
@@ -141,9 +136,9 @@
             this.height
           );
           
-          // Add small white dot to confirm real image is drawn
-          context.fillStyle = 'white';
-          context.fillRect(this.x, this.y, 4, 4);
+          // Small indicator dot for debugging (can be commented out for production)
+          // context.fillStyle = 'white';
+          // context.fillRect(this.x, this.y, 4, 4);
           
           console.log("Drawing player with image:", 
             `dimensions=${this.width}x${this.height}, position=(${Math.round(this.x)},${Math.round(this.y)})`);
@@ -169,19 +164,11 @@
       const centerX = this.x + radius;
       const centerY = this.y + radius;
       
-      // Draw a colored rectangle for visibility
-      context.strokeStyle = 'white';
-      context.lineWidth = 2;
-      context.strokeRect(this.x, this.y, this.width, this.height);
-      
       // Draw the player body - very bright yellow for maximum visibility
       context.fillStyle = '#FFFF00'; // Bright yellow
       context.beginPath();
       context.arc(centerX, centerY, radius - 2, 0, Math.PI * 2);
       context.fill();
-      context.strokeStyle = '#FFFFFF';
-      context.lineWidth = 1;
-      context.stroke();
       
       // Draw mouth based on animation state - make it larger and more visible
       context.fillStyle = '#000000';


### PR DESCRIPTION
This pull request focuses on removing debug and logging statements from the `gameEngine.js`, `ghost.js`, and `player.js` files to clean up the code for production. The most important changes include the removal of console logs, debug outlines, and other visual indicators used for debugging purposes.

### Removal of logging and debug statements:

* [`js/gameEngine.js`](diffhunk://#diff-c2a627ba4f30310aa8862375e6f12a9f5cce7174a81db7b08ef49b81c6f70a1bL576-L598): Removed multiple console logs that were used to log rendering confirmation, player position, ghost count, and maze details. Also removed the outline added to maze walls for better visibility. [[1]](diffhunk://#diff-c2a627ba4f30310aa8862375e6f12a9f5cce7174a81db7b08ef49b81c6f70a1bL576-L598) [[2]](diffhunk://#diff-c2a627ba4f30310aa8862375e6f12a9f5cce7174a81db7b08ef49b81c6f70a1bL663-L666) [[3]](diffhunk://#diff-c2a627ba4f30310aa8862375e6f12a9f5cce7174a81db7b08ef49b81c6f70a1bL676-L680)

* [`js/ghost.js`](diffhunk://#diff-b59b993458f92c3b592b7a6f063dedb5597ee3b1d3f88b60b0b11a620c33b945L196-L200): Removed debug outlines and small white dots used to confirm ghost positions and visibility. Some debug indicators were commented out instead of being removed entirely. [[1]](diffhunk://#diff-b59b993458f92c3b592b7a6f063dedb5597ee3b1d3f88b60b0b11a620c33b945L196-L200) [[2]](diffhunk://#diff-b59b993458f92c3b592b7a6f063dedb5597ee3b1d3f88b60b0b11a620c33b945L215-R212) [[3]](diffhunk://#diff-b59b993458f92c3b592b7a6f063dedb5597ee3b1d3f88b60b0b11a620c33b945L237-L241) [[4]](diffhunk://#diff-b59b993458f92c3b592b7a6f063dedb5597ee3b1d3f88b60b0b11a620c33b945L263-L265)

* [`js/player.js`](diffhunk://#diff-99193caa41c8aaea18158502d8cf21367a4697404da47b5e1ab25c1d0844072bL122-L126): Removed debug outlines and small white dots used to confirm player positions and visibility. Some debug indicators were commented out instead of being removed entirely. [[1]](diffhunk://#diff-99193caa41c8aaea18158502d8cf21367a4697404da47b5e1ab25c1d0844072bL122-L126) [[2]](diffhunk://#diff-99193caa41c8aaea18158502d8cf21367a4697404da47b5e1ab25c1d0844072bL144-R141) [[3]](diffhunk://#diff-99193caa41c8aaea18158502d8cf21367a4697404da47b5e1ab25c1d0844072bL172-L184)