### PR TITLE
Add Cortázar audio CTA and local fallback for greeting audio

### DIFF
--- a/game.js
+++ b/game.js
@@ -66,19 +66,30 @@
 
     // 4. Audio Pulse Button
     const audioBtn = document.getElementById('audio-pulse-btn');
+    const cortazarBtn = document.getElementById('cortazar-audio-btn');
     const audio = document.getElementById('saludo-audio');
 
     if (audioBtn && audio) {
+      const playGreeting = () => {
+        audio.currentTime = 0;
+        audio.play();
+        audioBtn.classList.add('playing');
+      };
+
       audioBtn.addEventListener('click', () => {
         if (audio.paused) {
-          audio.currentTime = 0;
-          audio.play();
-          audioBtn.classList.add('playing');
+          playGreeting();
         } else {
           audio.pause();
           audioBtn.classList.remove('playing');
         }
       });
+
+      if (cortazarBtn) {
+        cortazarBtn.addEventListener('click', () => {
+          playGreeting();
+        });
+      }
 
       audio.addEventListener('ended', () => {
         audioBtn.classList.remove('playing');

--- a/index.html
+++ b/index.html
@@ -48,6 +48,11 @@
     </header>
 
     <main>
+        <section class="audio-cta neo-card">
+            <p class="audio-cta-text">Cortázar would wink at the buzz — hear what people are saying about Carlos.</p>
+            <button id="cortazar-audio-btn" class="neo-btn">PLAY THE CORTÁZAR WHISPER</button>
+        </section>
+
         <div class="game-selector">
             <button class="selector-btn active" data-game="adventure">ADVENTURE</button>
             <button class="selector-btn" data-game="invaders">INVADERS</button>
@@ -115,7 +120,11 @@
         </div>
     </div>
 
-    <audio id="saludo-audio" src="assets/audio/saludo.mp3"></audio>
+    <audio id="saludo-audio">
+        <source src="assets/audio/saludo.mp3" type="audio/mpeg">
+        <source src="https://drive.google.com/uc?export=download&id=1f1Cisboh2mpkuv7UYbhw--seeGPqnzti"
+            type="audio/mpeg">
+    </audio>
 
     <!-- Scripts -->
     <script src="js/svgAssets.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -98,6 +98,22 @@ body {
     padding: 1rem 2rem;
 }
 
+.audio-cta {
+    max-width: 900px;
+    margin: 1rem auto 2.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.5rem;
+    background: var(--secondary-color);
+}
+
+.audio-cta-text {
+    font-weight: 900;
+    font-size: 1.2rem;
+    text-transform: uppercase;
+}
+
 h3 {
     font-weight: 900;
     font-size: 1.5rem;
@@ -107,6 +123,13 @@ h3 {
 .social-links {
     display: flex;
     gap: 1rem;
+}
+
+@media (max-width: 720px) {
+    .audio-cta {
+        flex-direction: column;
+        text-align: center;
+    }
 }
 
 .social-icon {


### PR DESCRIPTION
### Motivation
- Provide a Cortázar-themed call-to-action so visitors can play the greeting audio via a prominent button. 
- Avoid the Google Drive "preview not found" problem by falling back to a local `assets/audio/saludo.mp3` asset when the remote source is unavailable. 
- Reuse the existing audio control behavior so the new CTA doesn't duplicate playback logic.

### Description
- Add a new `.audio-cta` section and `#cortazar-audio-btn` button to `index.html` to surface the Cortázar-themed CTA and trigger playback. 
- Replace the single `src` audio attribute with multiple `<source>` entries in `index.html` so `assets/audio/saludo.mp3` is used as a local fallback before the Google Drive download URL. 
- Add styles for `.audio-cta` and `.audio-cta-text` plus a responsive rule in `styles.css` to layout the CTA and keep it usable on narrow viewports. 
- In `game.js` introduce a `playGreeting` helper and wire `#cortazar-audio-btn` to call it, reusing the existing pulse button state handling and ensuring playback behavior is consistent.

### Testing
- No automated tests were run for this follow-up change. 
- The prior Cortázar CTA rollout included a headless Playwright smoke test that loaded the page and captured a screenshot successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d01a5f3f083319834951116cb2527)