### PR TITLE
Add Brass Wings feature link

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,6 +98,21 @@
                     trying.</p>
             </div>
         </section>
+
+        <section id="featured-lab" class="neo-card">
+            <div class="featured-lab-copy">
+                <p class="lab-label">FEATURED WEARABLE EXPERIMENT</p>
+                <h2>BRASS WINGS</h2>
+                <p>A steampunk micro-flight game built for Meta Display Glasses: tiny waveguide display, canvas vector
+                    craft, one-scan add-to-glasses flow, and browser-native procedural audio.</p>
+            </div>
+            <div class="featured-lab-actions">
+                <a class="neo-link-btn primary-link" href="https://brasswings-webapp.pages.dev/" target="_blank"
+                    rel="noopener">OPEN LANDING PAGE</a>
+                <a class="neo-link-btn" href="https://github.com/macayaven/brasswings-webapp" target="_blank"
+                    rel="noopener">VIEW CODE</a>
+            </div>
+        </section>
     </main>
 
     <div id="panic-overlay">

--- a/styles.css
+++ b/styles.css
@@ -226,6 +226,71 @@ h3 {
     background: #eee;
 }
 
+#featured-lab {
+    width: min(1120px, calc(100% - 3rem));
+    margin: 1rem auto 4rem;
+    background: var(--secondary-color);
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 2rem;
+    align-items: center;
+}
+
+.lab-label {
+    display: inline-block;
+    margin-bottom: 0.75rem;
+    padding: 0.35rem 0.6rem;
+    background: #000;
+    color: var(--primary-color);
+    font-size: 0.8rem;
+    font-weight: 900;
+    letter-spacing: 0.04em;
+}
+
+#featured-lab h2 {
+    margin-bottom: 0.75rem;
+    font-size: clamp(2.4rem, 7vw, 5rem);
+    line-height: 0.9;
+    font-weight: 900;
+}
+
+#featured-lab p {
+    max-width: 720px;
+    font-weight: 700;
+    line-height: 1.45;
+}
+
+.featured-lab-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    justify-content: flex-end;
+}
+
+.neo-link-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 54px;
+    padding: 0 1.1rem;
+    background: #fff;
+    border: var(--border-width) solid #000;
+    box-shadow: var(--neobrutalist-shadow);
+    color: #000;
+    font-weight: 900;
+    text-decoration: none;
+    transition: transform 0.1s, box-shadow 0.1s;
+}
+
+.neo-link-btn.primary-link {
+    background: var(--primary-color);
+}
+
+.neo-link-btn:active {
+    transform: translate(2px, 2px);
+    box-shadow: 2px 2px 0px #000;
+}
+
 /* Game Styles */
 #game-container {
     margin-top: 4rem;
@@ -429,6 +494,14 @@ canvas {
         align-items: center;
     }
 
+    #featured-lab {
+        grid-template-columns: 1fr;
+    }
+
+    .featured-lab-actions {
+        justify-content: flex-start;
+    }
+
     .neo-card {
         padding: 1.25rem;
         max-width: 100% !important;
@@ -536,6 +609,10 @@ canvas {
     main>section {
         margin-top: 1.5rem !important;
         padding: 0.75rem !important;
+    }
+
+    #featured-lab {
+        width: calc(100% - 1.5rem);
     }
 
     .neo-card {


### PR DESCRIPTION
## Summary
- Adds a Brass Wings featured wearable experiment section to the GitHub Pages homepage.
- Links to the public Brass Wings landing page and repository.
- Keeps the section in the existing neobrutalist visual language of the page.

## Validation
- Served locally with `python3 -m http.server 5174`.
- Captured and visually reviewed a local screenshot of the new section.
